### PR TITLE
Corrections

### DIFF
--- a/book/content.rst
+++ b/book/content.rst
@@ -20,7 +20,7 @@ contenu à inclure. Voici un exemple de contenu.
       - section: "Chansons à boire"
       - "boire/*.csg"
       - section: "Chansons d'amour"
-      - sorted:
+      - sort:
           key: ["by", "title"]
           content: 
             - "amour/*.csg"
@@ -35,7 +35,7 @@ créer une section ayant pour titre *Chansons à boire*, tandis que
 
 .. code-block:: yaml
 
-      - sorted:
+      - sort:
           key: ["by", "title"]
           content: 
             - "amour/*.csg"
@@ -55,7 +55,7 @@ titre (c'est le tri par défaut) :
 .. code-block:: yaml
 
   content:
-    sorted:
+    sort:
 
 .. _content_types:
 
@@ -99,7 +99,7 @@ est possible d'en écrire d'autres.
 
 .. _plugin_sorted:
 
-:py:mod:`sorted` : liste triée de chansons
+:py:mod:`sort` : liste triée de chansons
   Ce plugin permet l'inclusion de chansons, triées selon un certain ordre.
   Il prend deux arguments (facultatifs): ``key`` pour la liste
   des champs selon lesquels les chansons de l'argument ``content`` doivent être triées. 
@@ -145,7 +145,7 @@ est possible d'en écrire d'autres.
 
   L'ordre de tri par défaut est : auteurs, album, titre.
 
-  Il faut remarque la liste de contenu de ``sorted`` n'est pas nécessairement
+  Il faut remarque la liste de contenu de ``sort`` n'est pas nécessairement
   une liste d'expression rationnelle : c'est n'importe quel élément de contenu
   qui renvoie une liste de chansons. Ainsi (en utilisant le plugin :py:mod:`cwd`
   décrit ci-après) le ``content`` suivant est parfaitement valide.
@@ -153,13 +153,13 @@ est possible d'en écrire d'autres.
   .. code-block:: yaml
   
     content:
-      sorted:
+      sort:
         content: 
           - cwd:
             path: repertoire
             content: "*.csg"
 
-  Une conséquence de cela est que ne pas donner de ``content`` à  ``sorted`` permet
+  Une conséquence de cela est que ne pas donner de ``content`` à  ``sort`` permet
   d'inclure toutes les chansons du répertoire :file:`songs`, récursivement.
 
 :py:mod:`cd` : changement de répertoire
@@ -190,7 +190,7 @@ est possible d'en écrire d'autres.
   sont recherché dans le sous-dossier  ``path`` relatif au répertoire :file:`songs` des :ref:`datadir <datadir>` (dans
   lequel sont cherchées les chansons par défaut).
 
-  Enfin, il faut remarquer que, tout comme le plugin :py:mod:`sorted`, la liste de
+  Enfin, il faut remarquer que, tout comme le plugin :py:mod:`sort`, la liste de
   contenu de :py:mod:`cd` n'est pas limitée à une liste d'expressions rationnelles
   correspondant à des chansons : elle peut être n'importe quel contenu
   correspondant à une liste de chansons. De plus, la commande
@@ -266,7 +266,7 @@ est possible d'en écrire d'autres.
      .. code-block:: yaml
 
         content:
-          - sorted:
+          - sort:
               content:
                 include: "amour.sbc"
   

--- a/index.rst
+++ b/index.rst
@@ -40,7 +40,7 @@ les autres outils).
 
 * `patacrep` regroupe les projets décrits ci-après (`patacrep`, `pataextra`,
   `patadata`, `patanet`, `patagui`) et est un ensemble d'outils de manipulation
-  de chants et de carnets de chants.
+  de chants et de carnets de chants ;
 * `patacrep/patacrep` est la bibliothèque principale, qui fournit les outils
   principaux nécessaires à cette manipulation, ainsi qu'un outil en ligne de
   commande (:ref:`songbook <songbookbin>`).

--- a/installation.rst
+++ b/installation.rst
@@ -70,7 +70,7 @@ MacOSX
 ^^^^^^
 
 Vous devrez installer les dépendaces suivantes:
- - `Python 3 <https://www.python.org/download/>`_ ;
+ - `Python 3 <https://www.python.org/download/>`_.
  - LaTeX. La distribution `MacTeX <https://tug.org/mactex/>`_ est la plus simple à installer. Une installation personnalisée de TeXLive fonctionnera aussi si vous savez ce que vous faites.
  - Lilypond peut être utile si vous souhaitez compiler les partitions dans les chansons. Ce n'est toutefois pas une dépendance obligatoire. Vous pouvez le télécharger à `cette adresse <http://www.lilypond.org/download.fr.html>`_. Décompressez l'archive, puis placez-la dans :file:`/Applications`. Vous devrez ajouter un lien vers lilypond pour que `songbook` puisse le trouver en lançant les commandes suivantes dans un Terminal : ::
 
@@ -176,7 +176,7 @@ Pour mettre à jour la version de développement, utilisez simplement ::
     pip3 install -r Requirements.txt
     python3 setup.py install
 
-Depuis le dossier :file:`patacrep`
+depuis le dossier :file:`patacrep`
 
 
 Mise à jour


### PR DESCRIPTION
I noticed that this documentation mentions the plugin `sorted` among the available content types, while the correct word seems to be `sort` ([songbook_fr.yaml, on line 14](https://github.com/patacrep/patadata/blob/master/books/songbook_fr.yaml)).

This PR fixes that, along with few minor typo fixes.